### PR TITLE
fix: pin doc requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-setuptools-scm = "*"
-sphinx = "*"
-m2r = "*"
+setuptools-scm==3.3.3
+sphinx==2.2.1
+m2r==0.2.1


### PR DESCRIPTION
## Context

Docs are not building in https://readthedocs.org/ due to malformed requirements.txt

## Description of changes

- fix syntax of docs/requirements.txt
- pin dependencies of doc building