### PR TITLE
Upload to pypi with twine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,11 @@ jobs:
             pipenv install --dev --deploy --skip-lock
       - deploy:
           command: |
-            echo "[pypi]\n  username = __token__\n  password = ${PYPI_TOKEN}" >> ~/.pypirc
+            echo "[distutils]"  > ~/.pypirc
+            echo "index-servers = pypi" >> ~/.pypirc
+            echo "[pypi]" >> ~/.pypirc
+            echo "username = __token__" >> ~/.pypirc
+            echo "password = ${PYPI_TOKEN}" >> ~/.pypirc
             pipenv run make upload-artifacts
       - store_artifacts:
           path: /app/dist/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
-            pip install -U pipenv
+            pip install -U pipenv twine
             pipenv install --dev --deploy --skip-lock
       - deploy:
           command: |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ build:
 	python setup.py bdist_wheel
 
 upload-artifacts: build
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 
 install-packages:
 	pipenv install


### PR DESCRIPTION
## Context

Apparently uploading with setuptools is deprecated, and will prevent fancy descriptions on the [package page](https://pypi.org/project/config-yourself/)

## Description of changes

- Fix pypi setup
- upload package with twine